### PR TITLE
Handle cases when there are no healthy servers 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "clap",
  "rand",
  "serde",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -514,6 +515,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ toml = "0.8.19"
 rand = "0.8.5"
 clap = { version = "4.5.16", features = ["derive"] }
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
+thiserror = "1.0.64"

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info, warn};
 
 use uuid::Uuid;
 
-use ekilibri::http::{parse_request, Method, ParseErrorKind, CRLF};
+use ekilibri::http::{parse_request, Method, ParsingError, CRLF};
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -55,7 +55,8 @@ async fn process_request(mut stream: TcpStream) {
         Ok((request, _)) => request,
         Err(e) => {
             let status = match e {
-                ParseErrorKind::MissingContentLength => "411",
+                ParsingError::MissingContentLength => "411",
+                ParsingError::HTTPVersionNotSupported => "505",
                 _ => "400",
             };
             let response = format!("HTTP/1.1 {status}{CRLF}{CRLF}");

--- a/tests/ekilibri_setup.py
+++ b/tests/ekilibri_setup.py
@@ -28,14 +28,18 @@ def initialize_command_server(
 
 
 def kill_process(pid):
-    os.kill(pid, signal.SIGTERM)
-    time.sleep(0.5)
+    if pid != -1:
+        os.kill(pid, signal.SIGTERM)
+        time.sleep(0.5)
 
 
 def setup_ekilibri_server(request, config_path: str) -> int:
     profile = request.config.getoption("--profile")
     attach_logs = request.config.getoption("--attach-logs")
-    return initialize_ekilibri_server(profile, attach_logs, config_path)
+    if request.config.getoption("--setup-server") == "true":
+        return initialize_ekilibri_server(profile, attach_logs, config_path)
+    else:
+        return -1
 
 
 def initialize_ekilibri_server(
@@ -67,3 +71,11 @@ def find_and_kill_command_server():
     name = "command"
     process = [p for p in processes if name in p.name()][0]
     os.kill(process.pid, signal.SIGTERM)
+
+
+def find_and_kill_all_command_servers():
+    processes = psutil.process_iter()
+    name = "command"
+    processes = [p for p in processes if name in p.name()]
+    for process in processes:
+        os.kill(process.pid, signal.SIGTERM)

--- a/tests/round_robin_test.py
+++ b/tests/round_robin_test.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from ekilibri_setup import (
+    find_and_kill_all_command_servers,
     find_and_kill_command_server,
     kill_process,
     setup_ekilibri_server,
@@ -45,6 +46,28 @@ def test_multiple_get_request_to_three_servers_with_two_failed(request):
         for _ in range(100):
             response = requests.get(URL + "/health")
             assert response.status_code == 200
+    finally:
+        kill_process(pid)
+
+
+def test_multiple_get_request_to_three_servers_with_all_failed(request):
+    pid = setup_ekilibri_server(request, "tests/ekilibri-round-robin.toml")
+    try:
+        response = requests.get(URL + "/health")
+        assert response.status_code == 200
+
+        find_and_kill_all_command_servers()
+
+        for _ in range(10):
+            response = requests.get(URL + "/health")
+            assert response.status_code == 502
+
+        # Wait the fail window for ekilibri to remove the server
+        sleep(10.5)
+
+        for _ in range(10):
+            response = requests.get(URL + "/health")
+            assert response.status_code == 504
     finally:
         kill_process(pid)
 


### PR DESCRIPTION
If there are no healthy servers Ekilibri will response with a
504(Gateway Timeout), given that no servers are reachable, while if the
servers are not reacheable, but still considered healthy, when the
inevitable connection error occur the response will be a 502(Bad
Gateway).

It was necessary to change the point where the parsing of the request
happens so that the request is always parsed before anything is written
to the client connection.