### PR TITLE
Add Dockerfile to run the tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target
+tests/__pycache__/**
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+on: [pull_request]
+
+name: CI
+
+jobs:
+  build_and_test:
+    name: Ekilibri Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: eaneto/ekilibri:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1-alpine3.18
+
+WORKDIR /usr/src/ekilibri
+
+COPY . .
+
+RUN apk add --no-cache musl-dev python3 py3-pip py3-psutil protoc
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
+RUN cargo install --path .
+
+RUN python3 -m pip install pytest requests
+
+RUN pytest -s tests --profile=docker


### PR DESCRIPTION
Creates a CI workflow for github, running cargo tests and the integration tests, for those we need a dockerfile so that the tests run on the image build.