### PR TITLE
Use timeouts from configuration in normal operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ load balancer.
 
 ## TODO
 
-- Use timeouts in the configuration file in the routed calls. Now
-  they are only being used in the health check process.
 - Enhance HTTP parsing implementation, parse headers over 4kB, support
   chunked transfer, support all methods.
 - Enhance error handling making sure the server won't crash.

--- a/tests/least_connections_test.py
+++ b/tests/least_connections_test.py
@@ -71,6 +71,16 @@ def test_multiple_get_request_to_three_servers_with_all_failed(request):
         kill_process(pid)
 
 
+def test_multiple_get_request_with_timeout(request):
+    pid = setup_ekilibri_server(request, "tests/ekilibri-least-connections.toml")
+    try:
+        for _ in range(10):
+            response = requests.get(URL + "/sleep")
+            assert response.status_code == 504
+    finally:
+        kill_process(pid)
+
+
 def test_echo_server(request):
     pid = setup_ekilibri_server(request, "tests/ekilibri-least-connections.toml")
     try:

--- a/tests/round_robin_test.py
+++ b/tests/round_robin_test.py
@@ -72,6 +72,16 @@ def test_multiple_get_request_to_three_servers_with_all_failed(request):
         kill_process(pid)
 
 
+def test_multiple_get_request_with_timeout(request):
+    pid = setup_ekilibri_server(request, "tests/ekilibri-round-robin.toml")
+    try:
+        for _ in range(10):
+            response = requests.get(URL + "/sleep")
+            assert response.status_code == 504
+    finally:
+        kill_process(pid)
+
+
 def test_echo_server(request):
     pid = setup_ekilibri_server(request, "tests/ekilibri-round-robin.toml")
     try:


### PR DESCRIPTION
The timeouts were initially only used in the health check process. Now the configuration for the connect, read and write timeouts are used in "normal" operations returning 504 in case the server does not respond in time.