### PR TITLE
Connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,10 +67,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "axum"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -101,9 +167,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
@@ -167,6 +233,8 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 name = "ekilibri"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "bytes",
  "clap",
  "rand",
  "serde",
@@ -183,6 +251,54 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "getrandom"
@@ -220,6 +336,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +431,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
@@ -264,10 +467,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -354,10 +569,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -432,6 +659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,11 +697,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -516,6 +789,18 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "thiserror"
@@ -612,11 +897,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ rand = "0.8.5"
 clap = { version = "4.5.16", features = ["derive"] }
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 thiserror = "1.0.64"
+axum = "0.7.7"
+bytes = "1.8.0"

--- a/ekilibri.toml
+++ b/ekilibri.toml
@@ -10,3 +10,4 @@ connection_timeout = 1000
 write_timeout = 1000
 read_timeout = 1000
 health_check_path = "/health"
+pool_size = 10

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -1,17 +1,15 @@
 use std::time::Duration;
 
-use clap::Parser;
-use tokio::{
-    io::AsyncWriteExt,
-    net::{TcpListener, TcpStream},
-    time,
+use axum::{
+    body::Bytes,
+    http::{header, HeaderMap, StatusCode},
+    routing::{get, post},
+    Router,
 };
+use clap::Parser;
+use tokio::{net::TcpListener, time};
 
-use tracing::{debug, info, warn};
-
-use uuid::Uuid;
-
-use ekilibri::http::{parse_request, Method, ParsingError, CRLF};
+use tracing::info;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -25,6 +23,12 @@ async fn main() {
 
     let args = Args::parse();
     let port = args.port;
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/sleep", get(sleep))
+        .route("/echo", post(echo));
+
     let listener = match TcpListener::bind(format!("127.0.0.1:{port}")).await {
         Ok(listener) => listener,
         Err(e) => panic!(
@@ -33,84 +37,30 @@ async fn main() {
         ),
     };
 
-    loop {
-        accept_and_handle_connection(&listener).await;
-    }
+    axum::serve(listener, app).await.unwrap();
 }
 
-async fn accept_and_handle_connection(listener: &TcpListener) {
-    match listener.accept().await {
-        Ok((stream, _)) => {
-            tokio::spawn(async move {
-                process_request(stream).await;
-            });
-        }
-        Err(_) => eprintln!("Error listening to socket"),
-    }
+async fn health() -> StatusCode {
+    info!("Received request for /health");
+    StatusCode::OK
 }
 
-async fn process_request(mut stream: TcpStream) {
-    let request_id = Uuid::new_v4();
-    let request = match parse_request(&request_id, &mut stream).await {
-        Ok((request, _)) => request,
-        Err(e) => {
-            let status = match e {
-                ParsingError::MissingContentLength => "411",
-                ParsingError::HTTPVersionNotSupported => "505",
-                _ => "400",
-            };
-            let response = format!("HTTP/1.1 {status}{CRLF}{CRLF}");
-            if let Err(e) = stream.write_all(response.as_bytes()).await {
-                debug!("Unable to send response to the client {e}");
-            }
-            return;
-        }
-    };
+async fn sleep() -> StatusCode {
+    info!("Received request for /sleep");
+    time::sleep(Duration::from_millis(2000)).await;
+    StatusCode::OK
+}
 
-    let response = match request.method {
-        Method::Get => match request.path.as_str() {
-            "/sleep" => {
-                info!("Received request for /sleep, request_id={request_id}");
-                time::sleep(Duration::from_millis(2000)).await;
-                format!("HTTP/1.1 200{CRLF}{CRLF}")
-            }
-            "/health" => {
-                info!("Received request for /health, request_id={request_id}");
-                format!("HTTP/1.1 200{CRLF}{CRLF}")
-            }
-            _ => {
-                info!("Received request for unmapped path, request_id={request_id}");
-                format!("HTTP/1.1 404{CRLF}{CRLF}")
-            }
-        },
-        Method::Post => match request.path.as_str() {
-            "/echo" => {
-                info!("Received request for /echo, request_id={request_id}");
-                let length = match request.headers.get("content-length") {
-                    Some(value) => value,
-                    None => "0",
-                };
-                let content_length = format!("Content-Length: {length}");
-                let content_type = match request.headers.get("content-type") {
-                    Some(value) => value,
-                    None => "text/plain",
-                };
-                let content_type = format!("Content-Type: {content_type}");
-                let body = request.body.unwrap_or_default();
-                format!("HTTP/1.1 200{CRLF}{content_length}{CRLF}{content_type}{CRLF}{CRLF}{body}")
-            }
-            _ => {
-                info!("Received request for unmapped path, request_id={request_id}");
-                format!("HTTP/1.1 404{CRLF}{CRLF}")
-            }
-        },
-        Method::Unknown => {
-            warn!("Received request for unmapped path, request_id={request_id}");
-            format!("HTTP/1.1 404{CRLF}{CRLF}")
-        }
+async fn echo(headers: HeaderMap, body: Bytes) -> Result<(HeaderMap, String), StatusCode> {
+    info!("Received request for /echo");
+    let content_type = match headers.get("content-type") {
+        Some(value) => value.to_str().unwrap(),
+        None => "text/plain",
     };
-
-    if let Err(e) = stream.write_all(response.as_bytes()).await {
-        debug!("Unable to send response to the client {e}");
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+    match String::from_utf8(body.to_vec()) {
+        Ok(body) => Ok((headers, body)),
+        Err(_) => Err(StatusCode::BAD_REQUEST),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod http;
+pub mod pool;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,166 @@
+use std::{
+    io,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{
+    net::TcpStream,
+    sync::{
+        mpsc::{Receiver, Sender},
+        Mutex,
+    },
+    time::timeout,
+};
+
+use tracing::{debug, trace, warn};
+
+pub struct Connection {
+    pub stream: TcpStream,
+    drop: bool,
+}
+
+impl Connection {
+    pub fn new(stream: TcpStream, drop: bool) -> Connection {
+        Connection { stream, drop }
+    }
+
+    fn should_drop(&self) -> bool {
+        self.drop
+    }
+}
+
+pub struct ConnectionPool {
+    server_id: usize,
+    size: usize,
+    timeout: u64,
+    server_address: String,
+    sender: Sender<Connection>,
+    reconnect: Arc<AtomicBool>,
+    receiver: Arc<Mutex<Receiver<Connection>>>,
+}
+
+impl ConnectionPool {
+    pub fn new(
+        id: usize,
+        size: usize,
+        timeout: u64,
+        server_address: &str,
+        sender: Sender<Connection>,
+        receiver: Receiver<Connection>,
+    ) -> ConnectionPool {
+        ConnectionPool {
+            server_id: id,
+            size,
+            timeout,
+            server_address: server_address.to_string(),
+            sender,
+            reconnect: Arc::new(AtomicBool::new(false)),
+            receiver: Arc::new(Mutex::new(receiver)),
+        }
+    }
+
+    pub fn set_reconnect(&self, reconnect: bool) {
+        self.reconnect.store(reconnect, Ordering::Relaxed);
+    }
+
+    pub fn is_reconnecting(&self) -> bool {
+        self.reconnect.load(Ordering::Relaxed)
+    }
+
+    pub async fn establish_connections(&self) {
+        for _ in 0..self.size {
+            match self.create_connection(false).await {
+                Ok(connection) => self.send_connection(connection).await,
+                Err(e) => {
+                    warn!("Error establishing connection in the pool, error={e}")
+                }
+            }
+        }
+    }
+
+    /// Locks the receiver and consumes every connection in the
+    /// channel until it is empty.
+    pub async fn drop_connections(&self) {
+        let mut receiver = self.receiver.lock().await;
+        while !receiver.is_empty() {
+            let _ = receiver.recv().await;
+        }
+    }
+
+    pub async fn get_connection(&self) -> Result<Connection, io::Error> {
+        if self.is_reconnecting() {
+            debug!(
+                "Creating a new connection with the server {}",
+                self.server_id
+            );
+            return self.create_connection(true).await;
+        }
+
+        match timeout(
+            Duration::from_millis(self.timeout),
+            self.receiver.lock().await.recv(),
+        )
+        .await
+        {
+            Ok(option) => match option {
+                Some(connection) => Ok(connection),
+                None => Err(io::Error::from(io::ErrorKind::TimedOut)),
+            },
+            Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
+        }
+    }
+
+    /// Returns the connection to the channel or drops the
+    /// connection if the pool is at the reconnect state.
+    pub async fn return_connection(&self, connection: Connection) {
+        if !connection.should_drop() {
+            trace!("Returning connection to the pool");
+            self.sender
+                .send(connection)
+                .await
+                .expect("Channel should be open");
+        }
+    }
+
+    pub async fn create_connection(&self, reconnecting: bool) -> Result<Connection, io::Error> {
+        match timeout(
+            Duration::from_millis(self.timeout),
+            TcpStream::connect(&self.server_address),
+        )
+        .await
+        {
+            Ok(result) => match result {
+                Ok(stream) => {
+                    if let Err(e) = stream.set_nodelay(true) {
+                        warn!("Error setting nodelay on stream, data will be buffered. error={e}");
+                    }
+                    Ok(Connection::new(stream, reconnecting))
+                }
+                Err(e) => {
+                    warn!(
+                        "Error while connecting to the server, {} might be down, {e}",
+                        self.server_id
+                    );
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                warn!(
+                    "Connection timeout, server {} might be down",
+                    self.server_id
+                );
+                Err(io::Error::new(io::ErrorKind::TimedOut, e))
+            }
+        }
+    }
+
+    pub async fn send_connection(&self, connection: Connection) {
+        self.sender
+            .send(connection)
+            .await
+            .expect("Channel should be open");
+    }
+}

--- a/tests/command_server_test.py
+++ b/tests/command_server_test.py
@@ -1,9 +1,6 @@
-import io
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
-
-import pytest
 import requests
+
+URL = "http://localhost:8081"
 
 
 def test_echo_server():
@@ -11,9 +8,7 @@ def test_echo_server():
 
     headers = {"Content-Length": str(len(payload))}
 
-    response = requests.post(
-        "http://localhost:8081/echo", headers=headers, data=payload
-    )
+    response = requests.post(URL + "/echo", headers=headers, data=payload)
 
     assert response.status_code == 200
     assert response.headers["Content-Length"] == str(len(payload))
@@ -26,9 +21,7 @@ def test_echo_server_with_content_type():
 
     headers = {"Content-Length": str(len(payload)), "Content-Type": "application/json"}
 
-    response = requests.post(
-        "http://localhost:8081/echo", headers=headers, data=payload
-    )
+    response = requests.post(URL + "/echo", headers=headers, data=payload)
 
     assert response.status_code == 200
     assert response.headers["Content-Length"] == str(len(payload))
@@ -36,29 +29,12 @@ def test_echo_server_with_content_type():
     assert response.text == payload
 
 
-def test_echo_server_without_content_type():
-    payload = """{"key": "value"}"""
-
-    headers = {"Content-Type": "application/json"}
-
-    url = "http://localhost:8081/echo"
-    data = io.BytesIO(payload.encode("utf-8"))
-
-    request = Request(url, data=data, headers=headers)
-    with pytest.raises(HTTPError) as error:
-        urlopen(request)
-
-    assert "411" in str(error)
-
-
 def test_echo_server_with_big_body():
     payload = "test parsing this info" * 1000
 
     headers = {"Content-Length": str(len(payload))}
 
-    response = requests.post(
-        "http://localhost:8081/echo", headers=headers, data=payload
-    )
+    response = requests.post(URL + "/echo", headers=headers, data=payload)
 
     assert response.status_code == 200
     assert response.headers["Content-Length"] == str(len(payload))
@@ -71,9 +47,7 @@ def test_echo_server_with_huge_body():
 
     headers = {"Content-Length": str(len(payload))}
 
-    response = requests.post(
-        "http://localhost:8081/echo", headers=headers, data=payload
-    )
+    response = requests.post(URL + "/echo", headers=headers, data=payload)
 
     assert response.status_code == 200
     assert response.headers["Content-Length"] == str(len(payload))
@@ -82,12 +56,12 @@ def test_echo_server_with_huge_body():
 
 
 def test_get_not_found():
-    response = requests.get("http://localhost:8081/not-found")
+    response = requests.get(URL + "/not-found")
     assert response.status_code == 404
     assert response.text == ""
 
 
 def test_post_not_found():
-    response = requests.post("http://localhost:8081/not-found", data="data")
+    response = requests.post(URL + "/not-found", data="data")
     assert response.status_code == 404
     assert response.text == ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from ekilibri_setup import kill_process, setup_command_server
 def pytest_addoption(parser):
     parser.addoption("--profile", action="store", default="local")
     parser.addoption("--setup-server", action="store", default="true")
-    parser.addoption("--attach-logs", action="store", default="false")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ekilibri-least-connections.toml
+++ b/tests/ekilibri-least-connections.toml
@@ -10,3 +10,4 @@ connection_timeout = 1000
 write_timeout = 1000
 read_timeout = 1000
 health_check_path = "/health"
+pool_size = 10

--- a/tests/ekilibri-round-robin-timeout.toml
+++ b/tests/ekilibri-round-robin-timeout.toml
@@ -10,3 +10,4 @@ connection_timeout = 1000
 write_timeout = 1000
 read_timeout = 1000
 health_check_path = "/sleep"
+pool_size = 10

--- a/tests/ekilibri-round-robin.toml
+++ b/tests/ekilibri-round-robin.toml
@@ -10,3 +10,4 @@ connection_timeout = 1000
 write_timeout = 1000
 read_timeout = 1000
 health_check_path = "/health"
+pool_size = 10

--- a/tests/ekilibri_setup.py
+++ b/tests/ekilibri_setup.py
@@ -35,16 +35,14 @@ def kill_process(pid):
 
 def setup_ekilibri_server(request, config_path: str) -> int:
     profile = request.config.getoption("--profile")
-    attach_logs = request.config.getoption("--attach-logs")
     if request.config.getoption("--setup-server") == "true":
-        return initialize_ekilibri_server(profile, attach_logs, config_path)
+        return initialize_ekilibri_server(profile, config_path)
     else:
         return -1
 
 
 def initialize_ekilibri_server(
     profile: str,
-    attach_logs: str,
     config_path: str,
     port: int = 8080,
     args: Optional[str] = None,
@@ -56,12 +54,7 @@ def initialize_ekilibri_server(
     command = [binary, "-f", config_path]
     if args is not None:
         command.extend(args.split(" "))
-    if attach_logs == "true":
-        process = subprocess.Popen(command)
-    else:
-        process = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     time.sleep(0.1)
     return process.pid
 

--- a/tests/least_connections_test.py
+++ b/tests/least_connections_test.py
@@ -59,14 +59,14 @@ def test_multiple_get_request_to_three_servers_with_all_failed(request):
 
         for _ in range(10):
             response = requests.get(URL + "/health")
-            assert response.status_code == 502
+            assert response.status_code == 502 or response.status_code == 504
 
         # Wait the fail window for ekilibri to remove the server
         sleep(10.5)
 
         for _ in range(10):
             response = requests.get(URL + "/health")
-            assert response.status_code == 504
+            assert response.status_code == 502
     finally:
         kill_process(pid)
 

--- a/tests/round_robin_test.py
+++ b/tests/round_robin_test.py
@@ -60,14 +60,14 @@ def test_multiple_get_request_to_three_servers_with_all_failed(request):
 
         for _ in range(10):
             response = requests.get(URL + "/health")
-            assert response.status_code == 502
+            assert response.status_code == 502 or response.status_code == 504
 
         # Wait the fail window for ekilibri to remove the server
         sleep(10.5)
 
         for _ in range(10):
             response = requests.get(URL + "/health")
-            assert response.status_code == 504
+            assert response.status_code == 502
     finally:
         kill_process(pid)
 


### PR DESCRIPTION
Creates a connection pool so that connections can be reused instead of
creating new connections. The pool has a fixed size, at start ekilibri
will try to establish the same number of connections in the
configuration file, errors are simply logged. The health check process
tries checks if the servers are healthy, when the server is unhealthy
all connections are dropped and the pool goes to "reconnect" state, in
this state every call to get a connection will establish a new
connection. When the server is considered healthy again, remaining
connections are dropped and new ones are established.

The command server was changed to use axum instead of a custom server,
this was done so that the tests run against a correct(already validated)
HTTP implementation, so bugs in ekilibri's implementation were caught
this way.